### PR TITLE
Drop python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = ["NeXus", "NXmx"]
 license = {text = "BSD 3-Clause License"}
 name = "nxmx"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [tool.setuptools.package-data]
 nxmx = ["py.typed"]


### PR DESCRIPTION
Add python 3.11 to testing matrix.

Latest versions of upstream dependencies are now dropping python 3.8 support

nxmx#18
https://github.com/hgrecco/pint/blob/3fb63af49df803e7bcad1fe9e6bdaab04021f4cc/CHANGES#L13