### PR TITLE
nxdetector.pixel_mask: return h5py.Dataset rather than np.array

### DIFF
--- a/src/nxmx/__init__.py
+++ b/src/nxmx/__init__.py
@@ -792,7 +792,7 @@ class NXdetector(H5Mapping):
         return None
 
     @cached_property
-    def pixel_mask(self) -> NXIntT | None:
+    def pixel_mask(self) -> h5py.Dataset | None:
         """The 32-bit pixel mask for the detector.
 
         Can be either one mask for the whole dataset (i.e. an array with indices i, j)
@@ -832,9 +832,7 @@ class NXdetector(H5Mapping):
 
         If provided, it is recommended that it be compressed.
         """
-        if "pixel_mask" in self._handle:
-            return self._handle["pixel_mask"][()]
-        return None
+        return self._handle.get("pixel_mask")
 
     @cached_property
     def bit_depth_readout(self) -> int | None:

--- a/tests/test_nxmx.py
+++ b/tests/test_nxmx.py
@@ -146,6 +146,7 @@ def nx_detector(request):
         distance.attrs["units"] = "m"
 
         detector.create_dataset("pixel_mask_applied", data=False, shape=shape)
+        detector.create_dataset("pixel_mask", data=np.zeros((2, 100, 200)))
 
         detector.create_dataset("saturation_value", data=12345, shape=shape)
 
@@ -171,6 +172,15 @@ def test_nxmx_single_value_properties(nx_detector):
         assert nx_detector.pixel_mask_applied is False
         assert nx_detector.saturation_value == 12345
         assert nx_detector.serial_number == "ABCDE"
+
+
+def test_nxdetector_pixel_mask(nx_detector):
+    with nx_detector as f:
+        nx_detector = nxmx.NXmx(f).entries[0].instruments[0].detectors[0]
+        assert isinstance(nx_detector.pixel_mask, h5py.Dataset)
+        assert nx_detector.pixel_mask.shape == (2, 100, 200)
+        assert nx_detector.pixel_mask[0].shape == (100, 200)
+        assert nx_detector.pixel_mask[1].shape == (100, 200)
 
 
 def test_get_rotation_axes(nxmx_example):


### PR DESCRIPTION
The `pixel_mask` can either be a single mask for the entire dataset or an array of masks for each image in the dataset. In the case of the latter we want to avoid reading the entire array of masks at once which the previous implementation resulted in.

Closes #17 